### PR TITLE
Draw before alert

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -53,10 +53,10 @@ function Board(rowCount = 3, columnCount = 3, winCondition = 3) {
 
     function checkLine(line) {
         if (line.includes("X".repeat(winCondition))) {
-            alert("Player 1 wins!");
+            setTimeout(() => {alert("Player 1 wins!");}, 100);
             return true;
         } else if (line.includes("O".repeat(winCondition))) {
-            alert("Player 2 wins!");
+            setTimeout(() => {alert("Player 2 wins!");}, 100);
             return true;
         }
     }

--- a/js/app.js
+++ b/js/app.js
@@ -91,7 +91,7 @@ function Board(rowCount = 3, columnCount = 3, winCondition = 3) {
         if ([...rows, ...columns, ...diagonals].some(checkLine)) {
             lockdown = 1;
         } else if (tiles.every(row => row.every(tile => tile.value !== EMPTY_TILE_TOKEN))) {
-            alert("It's a tie!");
+            setTimeout(() => {alert("It's a tie!");}, 100);
             lockdown = 1;
         }
     }


### PR DESCRIPTION
-- Closes issue #1 --
Added setTimeout() outside of the alerts for 'Player 1 wins!', 'Player 2 wins!', and 'It's a tie!' with a 100ms delay. This prevents the alert from occurring before the final square has been drawn. @khanhtranngoccva 